### PR TITLE
Improve partial withdrawal handling

### DIFF
--- a/src/api/api_v2/endpoints/rewards.py
+++ b/src/api/api_v2/endpoints/rewards.py
@@ -530,16 +530,7 @@ async def rewards(
             amount_withdrawn_this_day_wei = 0
             for w in validator_withdrawals:
                 if eod_balance.slot >= w.slot > prev_balance.slot:
-                    if w.amount_gwei > 8 * Decimal(1e9):
-                        # Assume full withdrawal
-                        if w.amount_gwei < 32 * Decimal(1e9):
-                            raise HTTPException(
-                                status_code=500,
-                                detail=f"Full withdrawal for {validator_index} with <32 ETH leads to negative income"
-                            )
-                        amount_withdrawn_this_day_wei += (w.amount_gwei % (32 * Decimal(1e9))) * Decimal(1e9)
-                    else:
-                        amount_withdrawn_this_day_wei += w.amount_gwei * Decimal(1e9)
+                    amount_withdrawn_this_day_wei += w.amount_gwei * Decimal(1e9)
             amount_earned_wei += amount_withdrawn_this_day_wei
 
             date = beacon_node.datetime_for_slot(


### PR DESCRIPTION
ethstaker.tax assumed any withdrawal higher than 8ETH was a full withdrawal of the initial 32ETH validator deposit, and discounted 32ETH from the CL rewards on that day.

However, with 0x02 validators that assumption no longer holds true, and with the way it was implemented (% 32), can actually be completely incorrect - a 65 ETH withdrawal from a 2000 ETH validator would be reported as 1 ETH in income.

With 0x02 validators, it becomes very difficult to properly account for this so I have simply removed this assumption and count any withdrawal as CL income. That will cause income "false positives" when a validator is exited but it allows people with 0x02 validators to use the website.

Relates to #102 #113 #121 